### PR TITLE
UQ-374: Show only the items belonging to the selected QModel

### DIFF
--- a/src/main/java/eu/uqasar/model/qmtree/QMTreeNode.java
+++ b/src/main/java/eu/uqasar/model/qmtree/QMTreeNode.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
@@ -78,7 +79,7 @@ public class QMTreeNode extends
 	protected QMTreeNode parent;
 
 	@XmlElement
-	@OneToMany(cascade = CascadeType.ALL)
+	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	@JoinColumn(name="parent_id")
 	@OrderColumn
 	@JsonManagedReference("parent")

--- a/src/main/java/eu/uqasar/web/pages/tree/subset/panel/SubsetProposalPanel.java
+++ b/src/main/java/eu/uqasar/web/pages/tree/subset/panel/SubsetProposalPanel.java
@@ -2,6 +2,8 @@ package eu.uqasar.web.pages.tree.subset.panel;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -98,8 +100,9 @@ public class SubsetProposalPanel extends Panel {
 
 		dataContainer.add(new CheckGroupSelector(
 				"dataGroupSelector", dataGroup));
-		
-		dataContainer.add(new ListView<QMTreeNode>("qmlist",qmTreeNodeService.getAllQModels()) {
+		List<QModel> qModelList = new LinkedList<>();
+		qModelList.add(project.getQmodel());
+		dataContainer.add(new ListView<QMTreeNode>("qmlist",qModelList) {
 			private static final long serialVersionUID = -8627579715676163392L;
 
 			@Override


### PR DESCRIPTION
If there are multiple QModels, the entries of the all QModels were shown even though only one QModel is selected. 