### PR TITLE
Removed SVN info at footer, no sense using git, problematic with coveralls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -741,23 +741,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<!-- Create SVN version number -->
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>buildnumber-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<phase>validate</phase>
-						<goals>
-							<goal>create</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<doCheck>false</doCheck>
-					<doUpdate>false</doUpdate>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
@@ -852,8 +835,6 @@
 							<archive>
 								<manifestEntries>
 									<Dependencies>org.jboss.msc</Dependencies>
-									<SCM-Revision>${buildNumber}</SCM-Revision>
-									<SCM-Branch>${scmBranch}</SCM-Branch>
 								</manifestEntries>
 							</archive>
 						</configuration>

--- a/src/main/java/eu/uqasar/web/pages/BasePage.html
+++ b/src/main/java/eu/uqasar/web/pages/BasePage.html
@@ -78,9 +78,6 @@
 			<footer>
 				<p>
 					<span wicket:id="footer"></span><br>
-					<wicket:message key="label.svn.version" /> 
-					<span wicket:id="buildNumber"></span> 
-					<span wicket:id="scmBranch"></span> 
 				</p>
 			</footer>
 		<script type="text/javascript">

--- a/src/main/java/eu/uqasar/web/pages/BasePage.java
+++ b/src/main/java/eu/uqasar/web/pages/BasePage.java
@@ -133,8 +133,6 @@ public abstract class BasePage extends WebPage {
 		// add the menu at the top
 		add(navbar = new HeaderNavigationBar("navbar", this));
 		setFooterYear();
-		add(newBuildNumberLabel());
-		add(newBranchLabel());
 		
 		SERVERNAMEANDPORT = getServerNameAndPort();
 		System.out.println("Current Server: "+SERVERNAMEANDPORT);
@@ -145,46 +143,7 @@ public abstract class BasePage extends WebPage {
 		String serverNameAndPort = req.getServerName() + ":" + req.getServerPort();
 		return serverNameAndPort;
 	}
-	
-	/**
-	 * 
-	 * @return the SVN version number 
-	 */
-	private Label newBuildNumberLabel() {
-		String buildNumber = "";
-		try {
-			Manifests.append(WebApplication.get().getServletContext());
-			buildNumber = Manifests.read("SCM-Revision");
-
-			logger.info("build number is: " + buildNumber);
-		} catch (Exception ex) {
-			// ignore if we can't get any version number
-			if (logger.isDebugEnabled()) {
-				logger.error("Could not read SCM-Revision from Manifest!", ex);
-			}
-		}
-		return new Label("buildNumber", buildNumber);
-	}
-
-	/**
-	 * @return the SVN branch 
-	 */
-	private Label newBranchLabel() {
-		String scmBranch = "";
-		try {
-			Manifests.append(WebApplication.get().getServletContext());
-			scmBranch = Manifests.read("SCM-Branch");
-			
-			logger.info("branch: " + scmBranch);
-		} catch (Exception ex) {
-			// ignore if we can't get any version number
-			if (logger.isDebugEnabled()) {
-				logger.error("Could not read SCM-Branch from Manifest!", ex);
-			}
-		}
-		return new Label("scmBranch", scmBranch);
-	}
-	
+		
     protected void setSearchTerm(final String query) {
         navbar.setSearchTerm(query);
     }

--- a/src/main/java/eu/uqasar/web/pages/BasePage.properties.xml
+++ b/src/main/java/eu/uqasar/web/pages/BasePage.properties.xml
@@ -46,7 +46,6 @@
 <entry key="footer.text">&amp;copy; {0,number,####} U-QASAR Consortium. All Rights Reserved.</entry>
 <entry key="label.metric.provider">Metric Provider</entry>
 <entry key="label.formula.editor">Formula</entry>
-<entry key="label.svn.version">SVN Version</entry>
 <entry key="label.unit">Unit</entry>
 <entry key="label.last.updated">Last Update</entry>
 </properties>

--- a/src/main/java/eu/uqasar/web/pages/BasePage_de.properties.xml
+++ b/src/main/java/eu/uqasar/web/pages/BasePage_de.properties.xml
@@ -46,7 +46,6 @@
 <entry key="footer.text">&amp;copy; {0,number,####} U-QASAR Konsortium. Alle Rechte vorbehalten.</entry>
 <entry key="label.metric.provider">Metrikquelle</entry>
 <entry key="label.formula.editor">Formel</entry>
-<entry key="label.svn.version">SVN Version</entry>
 <entry key="label.unit">Einheit</entry>
 <entry key="label.last.updated">Letzte Aktualisierung</entry>
 

--- a/src/main/java/eu/uqasar/web/pages/BasePage_fi.properties.xml
+++ b/src/main/java/eu/uqasar/web/pages/BasePage_fi.properties.xml
@@ -46,7 +46,6 @@
 <entry key="footer.text">&amp;copy; {0,number,####} U-QASAR-yhteenliittymä. Kaikki oikeudet pidätetään.</entry>
 <entry key="label.metric.provider">Metriikan tarjoaja</entry>
 <entry key="label.formula.editor">Kaava</entry>
-<entry key="label.svn.version">SVN-versio</entry>
 <entry key="label.unit">Yksikkö</entry>
 <entry key="label.last.updated">Viimeisin päivitys</entry>
 


### PR DESCRIPTION
If svn is not going to be used anymore, there is no reason to maintain. The plugin used to be shown the svn info causes some problems with coveralls while the report is being generated.